### PR TITLE
Added sorting and name searching features

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -3,6 +3,7 @@
         "lib/exrush_web.ex",
         "lib/exrush/application.ex",
         "lib/exrush_web/channels",
+        "lib/exrush_web/endpoint.ex",
         "lib/exrush_web/telemetry.ex",
         "lib/exrush_web/router.ex",
         "lib/exrush_web/views/error_helpers.ex",

--- a/lib/exrush.ex
+++ b/lib/exrush.ex
@@ -1,12 +1,10 @@
 defmodule Exrush do
   @moduledoc """
-  Exrush keeps the contexts that define your domain
-  and business logic.
-
-  Contexts are also responsible for managing your data, regardless
-  if it comes from the database, an external API or others.
+  Exrush is the module that contains the main business logic.
   """
 
+  @allowed_sort_fields ["Yds", "Lng", "TD"]
+  @allowed_filters [:asc, :desc]
   @rushing_path "priv/rushing.json"
 
   @doc """
@@ -19,13 +17,40 @@ defmodule Exrush do
     |> Jason.decode!()
   end
 
-  # def sort(rushing_list, field, :asc) do
-  #  rushing_list
-  #  |> Enum.sort(&(&1[field] <= &2[field]))
-  # end
+  @doc """
+  Filters the rushing data players by its player.
+  Uses a simple algorithm that looks for a containing match in the data.
+  """
+  @spec player_filter(binary()) :: list(map())
+  def player_filter(search) when is_binary(search) do
+    Exrush.RushingReader.get_rushing()
+    |> Enum.filter(&String.contains?(&1["Player"] |> String.downcase(), String.downcase(search)))
+  end
 
-  # def sort(rushing_list, field, :desc) do
-  #  rushing_list
-  #  |> Enum.sort(&(&1[field] >= &2[field]))
-  # end
+  def player_filter(_search), do: []
+
+  @doc """
+  Sorts the rushing data list by an specified list.
+  Accepts both :asc and :desc order.
+  """
+  @spec sort(binary(), atom()) :: list(map())
+  def sort(field, filter) when field in @allowed_sort_fields and filter in @allowed_filters do
+    Exrush.RushingReader.get_rushing()
+    |> sort(field, filter)
+  end
+
+  def sort(_field, _filter), do: []
+
+  defp sort(rushing_list, field, :asc) do
+    rushing_list
+    |> Enum.sort(&(parse_sort_value(&1[field]) <= parse_sort_value(&2[field])))
+  end
+
+  defp sort(rushing_list, field, :desc) do
+    rushing_list
+    |> Enum.sort(&(parse_sort_value(&1[field]) >= parse_sort_value(&2[field])))
+  end
+
+  defp parse_sort_value(value) when is_integer(value), do: value
+  defp parse_sort_value(value) when is_binary(value), do: Integer.parse(value) |> elem(0)
 end

--- a/test/exrush/exrush_test.exs
+++ b/test/exrush/exrush_test.exs
@@ -28,4 +28,49 @@ defmodule ExrushTest do
       assert_raise File.Error, fn -> Exrush.read_rushing("invalid_file") end
     end
   end
+
+  describe "player_filter/1" do
+    test "Searching some existing player's name will return at least one result" do
+      result = Exrush.player_filter("Shaun")
+
+      assert Enum.count(result) >= 1
+    end
+
+    test "Searching for a non-existing player returns an empty list" do
+      result = Exrush.player_filter("invalid_player")
+
+      assert [] = result
+    end
+
+    test "Searching with something that is not a binary will return an empty list" do
+      result = Exrush.player_filter(1234)
+
+      assert [] = result
+    end
+  end
+
+  describe "sort/2" do
+    test "Sorting by any of the allowed fields returns a sortered list of data" do
+      result_asc = Exrush.sort("TD", :asc)
+      result_desc = Exrush.sort("TD", :desc)
+      result_asc_lng = Exrush.sort("Lng", :asc)
+
+      assert List.first(result_asc)["TD"] <= List.last(result_asc)["TD"]
+      assert List.first(result_desc)["TD"] >= List.last(result_desc)["TD"]
+
+      assert List.first(result_asc)["Lng"] |> parse_value() <=
+               List.last(result_asc)["Lng"] |> parse_value()
+    end
+
+    test "Attempting to sort by a non-allowed field or filter will return an empty list" do
+      result1 = Exrush.sort("NonAllowedField", :asc)
+      result2 = Exrush.sort("TD", :non_allowed_filter)
+
+      assert [] = result1
+      assert [] = result2
+    end
+  end
+
+  defp parse_value(value) when is_integer(value), do: value
+  defp parse_value(value) when is_binary(value), do: Integer.parse(value) |> elem(0)
 end


### PR DESCRIPTION
In order to sort by _Total Rushing Yards_, _Longest Rush_ or
_Total Rushing Touchdowns_, we have added a `sort/2` function that allows us
to do it.

Same thing also to search by players' name with a new `player_filter/1`
function.

Finally, added some tests to cover the new features.